### PR TITLE
Added constructor argument to choose pinMode for encoder pins

### DIFF
--- a/src/AiEsp32RotaryEncoder.cpp
+++ b/src/AiEsp32RotaryEncoder.cpp
@@ -179,7 +179,7 @@ void IRAM_ATTR AiEsp32RotaryEncoder::readButton_ISR()
 #endif
 }
 
-AiEsp32RotaryEncoder::AiEsp32RotaryEncoder(uint8_t encoder_APin, uint8_t encoder_BPin, int encoder_ButtonPin, int encoder_VccPin, uint8_t encoderSteps)
+AiEsp32RotaryEncoder::AiEsp32RotaryEncoder(uint8_t encoder_APin, uint8_t encoder_BPin, int encoder_ButtonPin, int encoder_VccPin, uint8_t encoderSteps, bool pullUp)
 {
 	this->old_AB = 0;
 
@@ -190,11 +190,11 @@ AiEsp32RotaryEncoder::AiEsp32RotaryEncoder(uint8_t encoder_APin, uint8_t encoder
 	this->encoderSteps = encoderSteps;
 
 #if defined(ESP8266)
-	pinMode(this->encoderAPin, INPUT_PULLUP);
-	pinMode(this->encoderBPin, INPUT_PULLUP);
+	pinMode(this->encoderAPin, pullUp ? INPUT_PULLUP : INPUT_PULLDOWN);
+	pinMode(this->encoderBPin, pullUp ? INPUT_PULLUP : INPUT_PULLDOWN);
 #else
-	pinMode(this->encoderAPin, (areEncoderPinsPulldownforEsp32? INPUT_PULLDOWN:INPUT_PULLUP));
-	pinMode(this->encoderBPin, (areEncoderPinsPulldownforEsp32? INPUT_PULLDOWN:INPUT_PULLUP));
+	pinMode(this->encoderAPin, pullUp ? INPUT_PULLUP : INPUT_PULLDOWN);
+	pinMode(this->encoderBPin, pullUp ? INPUT_PULLUP : INPUT_PULLDOWN);
 #endif
 }
 

--- a/src/AiEsp32RotaryEncoder.h
+++ b/src/AiEsp32RotaryEncoder.h
@@ -17,6 +17,12 @@
 #define AIESP32ROTARYENCODER_DEFAULT_VCC_PIN -1
 #define AIESP32ROTARYENCODER_DEFAULT_STEPS 2
 
+#if defined(ESP8266)
+	#define AIESP32ROTARYENCODER_DEFAULT_PINMODE_PULLUP true
+#else
+	#define AIESP32ROTARYENCODER_DEFAULT_PINMODE_PULLUP false
+#endif
+
 typedef enum
 {
 	BUT_DOWN = 0,
@@ -69,11 +75,12 @@ public:
 		uint8_t encoderBPin = AIESP32ROTARYENCODER_DEFAULT_B_PIN,
 		int encoderButtonPin = AIESP32ROTARYENCODER_DEFAULT_BUT_PIN,
 		int encoderVccPin = AIESP32ROTARYENCODER_DEFAULT_VCC_PIN,
-		uint8_t encoderSteps = AIESP32ROTARYENCODER_DEFAULT_STEPS);
+		uint8_t encoderSteps = AIESP32ROTARYENCODER_DEFAULT_STEPS,
+		bool pullUp = AIESP32ROTARYENCODER_DEFAULT_PINMODE_PULLUP
+		);
 	void setBoundaries(long minValue = -100, long maxValue = 100, bool circleValues = false);
 	int correctionOffset=2;
 	bool isButtonPulldown = false;
-	bool areEncoderPinsPulldownforEsp32 = true;
 #if defined(ESP8266)
 	ICACHE_RAM_ATTR void readEncoder_ISR();
 	ICACHE_RAM_ATTR void readButton_ISR();


### PR DESCRIPTION
Hi!
My ESP32 based PCB has an encoder that is connected to GND so my pins have to be pulled up. Unfortunately the pinMode is set in the constructor and I cannot change the variable `areEncoderPinsPulldownforEsp32` before creating the AiEsp32RotaryEncoder object. That's why I extended the constructor arguments and set the default values so it won't change the current behavior.